### PR TITLE
adding terminal args for chainfile name control

### DIFF
--- a/openmc_data/depletion/generate_endf71_chain.py
+++ b/openmc_data/depletion/generate_endf71_chain.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+from argparse import ArgumentParser
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -14,6 +15,17 @@ URLS = [
     'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-decay.zip',
     'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-nfy.zip'
 ]
+
+# Parse command line arguments
+parser = ArgumentParser()
+parser.add_argument(
+    "-d",
+    "--destination",
+    type=Path,
+    default='chain_endfb71.xml',
+    help="filename of the chain file xml file produced.",
+)
+args = parser.parse_args()
 
 
 def main():
@@ -45,7 +57,8 @@ def main():
             raise IOError("No {} endf files found in {}".format(ftype, endf_dir))
 
     chain = openmc.deplete.Chain.from_endf(decay_files, nfy_files, neutron_files)
-    chain.export_to_xml('chain_endfb71.xml')
+
+    chain.export_to_xml(args.destination)
 
 
 if __name__ == '__main__':

--- a/openmc_data/depletion/generate_endf71_chain_casl.py
+++ b/openmc_data/depletion/generate_endf71_chain_casl.py
@@ -2,6 +2,8 @@
 
 import glob
 import os
+from argparse import ArgumentParser
+from pathlib import Path
 from zipfile import ZipFile
 from collections import defaultdict
 from io import StringIO
@@ -26,6 +28,17 @@ URLS = [
     'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-decay.zip',
     'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-nfy.zip'
 ]
+
+# Parse command line arguments
+parser = ArgumentParser()
+parser.add_argument(
+    "-d",
+    "--destination",
+    type=Path,
+    default='chain_casl.xml',
+    help="filename of the chain file xml file produced.",
+)
+args = parser.parse_args()
 
 
 def replace_missing_decay_product(product, decay_data, all_decay_data):
@@ -263,7 +276,7 @@ def main():
             print('  {}, replaced with {}'.format(parent, replacement))
         print('')
 
-    chain.export_to_xml('chain_casl.xml')
+    chain.export_to_xml(args.destination)
 
 
 if __name__ == '__main__':

--- a/openmc_data/depletion/generate_serpent_fissq.py
+++ b/openmc_data/depletion/generate_serpent_fissq.py
@@ -13,6 +13,13 @@ import openmc.data
 # Get command line argument
 parser = ArgumentParser()
 parser.add_argument('dir', type=Path, help='Directory containing ENDF neutron sublibrary files')
+parser.add_argument(
+    "-d",
+    "--destination",
+    type=Path,
+    default='serpent_fissq.json',
+    help="filename of the heating values file produced",
+)
 args = parser.parse_args()
 
 
@@ -37,5 +44,5 @@ def main():
         serpent_fission_q[nuc.name] = heat_u235 * q / q_u235
 
     # Write heating values to JSON file
-    with open('serpent_fissq.json', 'w') as f:
+    with open(args.destination, 'w') as f:
         json.dump(serpent_fission_q, f, indent=2)

--- a/openmc_data/depletion/generate_tendl_chain.py
+++ b/openmc_data/depletion/generate_tendl_chain.py
@@ -27,6 +27,14 @@ parser.add_argument('-r', '--release', choices=['2019', '2021'],
                     default='2021', help="The nuclear data library release "
                     "version. The currently supported options are 2019, "
                     "and 2021.")
+parser.add_argument(
+    "-d",
+    "--destination",
+    type=Path,
+    default=None,
+    help="filename of the chain file xml file produced. If left as None then "
+    "the filename will follow this format 'chain_tendl_{release}_{lib}.xml'",
+)
 args = parser.parse_args()
 
 
@@ -141,7 +149,11 @@ def main():
         decay_files, nfy_files, neutron_files,
         reactions=dep.chain.REACTIONS.keys()
     )
-    chain.export_to_xml(f'chain_{library_name}_{args.release}_{args.lib}.xml')
+
+    if args.destination is None:
+        chain.export_to_xml(f'chain_{library_name}_{args.release}_{args.lib}.xml')
+    else:
+        chain.export_to_xml(args.destination)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this adds args to all the depletion scripts so their existance can be checked without the ```--help``` terminal option and they don't actually run