### PR TITLE
added nndc to url testing

### DIFF
--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -38,6 +38,8 @@ jobs:
           cd ..
           pip install .[tests]
 
+      # the -s allows normal print statements in the url testing to be seen in
+      # the pytest output 
       - name: test urls
         run: |
-          pytest -v tests/test_urls.py
+          pytest -v -s tests/test_urls.py

--- a/openmc_data/urls.py
+++ b/openmc_data/urls.py
@@ -205,4 +205,40 @@ all_release_details = {
             },
         },
     },
+    'nndc': {
+        "b7.1": {
+            "neutron": {
+                "base_url": "http://www.nndc.bnl.gov/endf-b7.1/aceFiles/",
+                "compressed_files": [
+                    "ENDF-B-VII.1-neutron-293.6K.tar.gz",
+                    "ENDF-B-VII.1-tsl.tar.gz",
+                ],
+                "checksums": [
+                    "9729a17eb62b75f285d8a7628ace1449",
+                    "e17d827c92940a30f22f096d910ea186",
+                ],
+                "file_type": "ace",
+                "ace_files": "[aA-zZ]*.ace",
+                "sab_files": "*.acer",
+                "compressed_file_size": 497,
+                "uncompressed_file_size": 1200,
+            },
+            "photon": {
+                "base_url": "http://www.nndc.bnl.gov/endf-b7.1/zips/",
+                "compressed_files": [
+                    "ENDF-B-VII.1-photoat.zip",
+                    "ENDF-B-VII.1-atomic_relax.zip",
+                ],
+                "checksums": [
+                    "5192f94e61f0b385cf536f448ffab4a4",
+                    "fddb6035e7f2b6931e51a58fc754bd10",
+                ],
+                "file_type": "endf",
+                "photo_files": "photoat/*.endf",
+                "atom_files": "atomic_relax/*.endf",
+                "compressed_file_size": 9,
+                "uncompressed_file_size": 45,
+            },
+        }
+    }
 }

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -8,6 +8,7 @@ def test_tendl_urls():
     """Cycles through all the urls in each nuclear data library and checks
     that they return a status 200 code (success)"""
 
+    print("library, release, particle, responce.status_code")
     for library, releases in all_release_details.items():
         for release, particles in releases.items():
             for particle, value in particles.items():


### PR DESCRIPTION
adds convert_nndc 71 to the url testing

Note this PR should trigger selective tests for the convert_nndc script as this script has changed. The other convert scripts won't be run in full as they have not changed.

The urls pinged now include tendl, fend and nndc, we are getting there :-)