### PR TITLE
Moving jeff decay to json file

### DIFF
--- a/src/openmc_data/depletion/generate_tendl_chain.py
+++ b/src/openmc_data/depletion/generate_tendl_chain.py
@@ -112,17 +112,17 @@ def main():
     print(neutron_files)
     # ==========================================================================
     # Decay and fission product yield data
-
+    print(release_details)
     decay_zip = download(
         urljoin(
-            release_details["decay"]["base_url"],
+            release_details["decay"]["base_url"][0],
             release_details["decay"]["compressed_files"][0],
         ),
         output_path=decay_dir,
     )
     nfy_zip = download(
         urljoin(
-            release_details["nfy"]["base_url"],
+            release_details["nfy"]["base_url"][0],
             release_details["nfy"]["compressed_files"][0],
         ),
         output_path=nfy_dir,

--- a/src/openmc_data/depletion/generate_tendl_chain.py
+++ b/src/openmc_data/depletion/generate_tendl_chain.py
@@ -85,23 +85,11 @@ def main():
 
     # adds in either jeff or endf neutron fission yields and decay data
     if args.lib == "jeff33":
-        release_details["decay"] = {
-            "base_url": "https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/",
-            "compressed_files": ["JEFF33-rdd.zip"],
-        }
-        release_details["nfy"] = {
-            "base_url": "https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/",
-            "compressed_files": ["JEFF33-nfy.asc"],
-        }
+        release_details["decay"] = all_decay_release_details['jeff']['3.3']["decay"]
+        release_details["nfy"] = all_decay_release_details['jeff']['3.3']["nfy"]
     elif args.lib == "endf80":
-        release_details["decay"] = {
-            "base_url": "https://www.nndc.bnl.gov/endf-b8.0/zips/",
-            "compressed_files": ["ENDF-B-VIII.0_decay.zip"],
-        }
-        release_details["nfy"] = {
-            "base_url": "https://www.nndc.bnl.gov/endf-b8.0/zips/",
-            "compressed_files": ["ENDF-B-VIII.0_nfy.zip"],
-        }
+        release_details["decay"] = all_decay_release_details['endf']['b8.0']["decay"]
+        release_details["nfy"] = all_decay_release_details['endf']['b8.0']["nfy"]
     else:
         raise ValueError(
             f"lib argument must be either jeff33 or endf80 and can not be {args.lib}"

--- a/src/openmc_data/urls_chain.py
+++ b/src/openmc_data/urls_chain.py
@@ -33,15 +33,15 @@ all_decay_release_details = {
         '3.3': {
             'neutron': {
                 'base_url': ['https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/temperatures/'],
-                'compressed_files': ['ace_293.tar.gz'],
+                'compressed_files': ['ace_293.tar.gz']
             },
             'decay': {
                 'base_url': ['https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/'],
                 'compressed_files': ['JEFF33-rdd.zip']
             },
             'nfy': {
-                'base_url': [''],
-                'compressed_files': ['']
+                'base_url': ['https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/'],
+                'compressed_files': ['JEFF33-nfy.asc']
             }       
         }
     },

--- a/src/openmc_data/urls_chain.py
+++ b/src/openmc_data/urls_chain.py
@@ -29,6 +29,22 @@ all_decay_release_details = {
                 }
             }
         },
+    'jeff': {
+        '3.3': {
+            'neutron': {
+                'base_url': ['https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/temperatures/'],
+                'compressed_files': ['ace_293.tar.gz'],
+            },
+            'decay': {
+                'base_url': ['https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/'],
+                'compressed_files': ['JEFF33-rdd.zip']
+            },
+            'nfy': {
+                'base_url': [''],
+                'compressed_files': ['']
+            }       
+        }
+    },
     'tendl': {
         '2015': {
             'neutron':{

--- a/src/openmc_data/urls_xml.py
+++ b/src/openmc_data/urls_xml.py
@@ -2,12 +2,12 @@ all_chain_release_details = {
     "endf": {
         "b7.1": {
             "chain": {
-                "url": "https://github.com/openmc-data-storage/openmc_data/raw/main/src/openmc_data/depletion/chain_endf_7.1.xml",
+                "url": "https://github.com/openmc-data-storage/openmc_data/raw/main/src/openmc_data/depletion/chain_endf_b7.1.xml",
             }
         },
         "b8.0": {
             "chain": {
-                "url": "https://github.com/openmc-data-storage/openmc_data/raw/main/src/openmc_data/depletion/chain_endf_8.0.xml",
+                "url": "https://github.com/openmc-data-storage/openmc_data/raw/main/src/openmc_data/depletion/chain_endf_b8.0.xml",
             }
         },
     }


### PR DESCRIPTION
urls were hard coded in the file.

these are now in json file where other scripts can use them