### PR TITLE
include errata in jendl5

### DIFF
--- a/src/openmc_data/generate/generate_jendl.py
+++ b/src/openmc_data/generate/generate_jendl.py
@@ -85,10 +85,15 @@ def main():
     # EXTRACT FILES FROM TGZ
     if args.extract:
         extract(
-            compressed_files=[download_path/ f for f in details['compressed_files']],
+            compressed_files=[download_path / f for f in details['compressed_files']],
             extraction_dir=endf_files_dir,
             del_compressed_file=args.cleanup
         )
+    for erratum in details["errata"]:
+        files = Path('.').rglob(erratum)
+        for p in files:
+            p.rename((endf_files_dir / details["endf_files"]).parent / p.name)
+            
 
     # ==============================================================================
     # GENERATE HDF5 LIBRARY -- NEUTRON FILES

--- a/src/openmc_data/urls.py
+++ b/src/openmc_data/urls.py
@@ -459,8 +459,12 @@ all_release_details = {
             'neutron': {
                 'endf':{
                     'base_url': 'https://wwwndc.jaea.go.jp/ftpnd/ftp/JENDL/',
-                    'compressed_files': ['jendl5-n.tar.gz'],
+                    'compressed_files': ['jendl5-n.tar.gz', 'jendl5-n_upd1.tar.gz',
+                                         'jendl5-n_upd6.tar.gz', 'jendl5-n_upd7.tar.gz',
+                                         'jendl5-n_upd10.tar.gz', 'jendl5-n_upd11.tar.gz',
+                                         'jendl5-n_upd12.tar.gz'],
                     'endf_files': 'jendl5-n/*.dat',
+                    'errata': ['jendl5-n_upd1/*.dat', 'jendl-n_upd6/*.dat', '*.dat'],
                     'metastables': 'jendl5-n/*m1.dat',
                     'compressed_file_size': 4.1,
                     'uncompressed_file_size': 16


### PR DESCRIPTION
This PR adresses [this](https://github.com/openmc-data-storage/openmc_data/issues/2) issue, the problem with jendl-5.0 generation was that the downloaded data did not include errata published [here](https://wwwndc.jaea.go.jp/jendl/j5/JENDL-5_Errata.html) by JAEA.

This PR adds errata URLs to the urls.py file, these errata are all downloaded, extracted, and the resulting endf files moved to the correct location when running `generate_jendl.py -r  5.0`.

NJOY treatment then continues on correctly to create the hdf5 data files.