### PR TITLE
fix gnd to gnds

### DIFF
--- a/src/openmc_data/depletion/generate_endf71_chain_casl.py
+++ b/src/openmc_data/depletion/generate_endf71_chain_casl.py
@@ -97,7 +97,7 @@ def main():
     reactions = {}
     for f in neutron_files:
         evaluation = openmc.data.endf.Evaluation(f)
-        nuc_name = evaluation.gnd_name
+        nuc_name = evaluation.gnds_name
         if nuc_name in CASL_CHAIN:
             reactions[nuc_name] = {}
             for mf, mt, nc, mod in evaluation.reaction_list:


### PR DESCRIPTION
This fixes the call to the `openmc.data.endf.Evaluation.gnd_name` property which has been renamed to  `openmc.data.endf.Evaluation.gnds_name` as per [this ](https://github.com/openmc-dev/openmc/commit/ecfa94e0ff0c50a83c8db61444e5cad888b16c7a#diff-0fff817e63b2ffdb168a0d8ef76670817f09b452937c62bc582b9a9c6090e2b2) commit.