### PR TITLE
Fix jeff CI issue

### DIFF
--- a/.github/workflows/test_processing.yml
+++ b/.github/workflows/test_processing.yml
@@ -30,9 +30,11 @@ jobs:
         with:
           files: |
             src/openmc_data/convert/convert_*.py
+            src/openmc_data/other/convert_tendl_rand.py
             src/openmc_data/download/download_*.py
             src/openmc_data/depletion/add_branching_ratios.py
             src/openmc_data/depletion/reduce_chain.py
+            src/openmc_data/utils.py
 
       - name: Set up Python
         if: steps.changed-files-specific.outputs.any_changed == 'true'
@@ -61,7 +63,7 @@ jobs:
       # convert_lib80x.py convert_mcnp70.py convert_mcnp71.py files are not tested here
 
       - name: test default convert_fendl
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert_fendl.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_fendl.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "convert_fendl.py file has been modified."
           convert_fendl --cleanup
@@ -69,51 +71,51 @@ jobs:
       # this running convert_jeff32 in with default arguments produces 49GB of
       # data. Hence the use of arguments to process just one temperature
       - name: test default convert_jeff32
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_jeff32.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_jeff32.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "convert_jeff32.py file has been modified."
           convert_jeff32 -r 3.2 -t 293 --cleanup
 
       - name: test default convert_jeff33
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_jeff33.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_jeff33.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "convert_jeff33.py file has been modified."
           convert_jeff33 -r 3.3 -t 293 --cleanup
 
       - name: test default convert_endf
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_endf.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_endf.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "convert_endf.py file has been modified."
           convert_endf --cleanup
 
       - name: test default convert_tendl
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_tendl.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_tendl.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "convert_tendl.py file has been modified."
           convert_tendl --cleanup
 
       - name: test default convert_tendl_rand
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/convert/convert_tendl_rand.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/other/convert_tendl_rand.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "convert_tendl_rand.py file has been modified."
           convert_tendl_rand --nuclides O16 --cleanup
 
       # download scripts
       - name: test default download_endf
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/download/download_endf.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/download/download_endf.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "download_endf.py file has been modified."
           download_endf
 
       - name: test default download_tendl
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/download/download_tendl.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/download/download_tendl.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "download_tendl.py file has been modified."
           download_tendl -r 2019
           download_tendl -r 2021
 
       - name: test default download_chain
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/download/download_chain.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/download/download_chain.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "download_chain.py file has been modified."
           download_chain -l endf -r b7.1 -b None
@@ -125,7 +127,7 @@ jobs:
           download_chain -l endf -r b8.0 -b PWR
 
       - name: test default add_branching_ratios
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/depletion/add_branching_ratios.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/depletion/add_branching_ratios.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "add_branching_ratios.py file has been modified."
           download_chain -l endf -r b8.0
@@ -133,7 +135,7 @@ jobs:
           add_branching_ratios -i chain-endf-b8.0.xml -o chain_endf_b8.0_pwr.xml -b pwr
 
       - name: test default reduce_chain
-        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/depletion/reduce_chain.py')
+        if: contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/depletion/reduce_chain.py') || contains(steps.changed-files-specific.outputs.modified_files, 'src/openmc_data/utils.py')
         run: |
           echo "reduce_chain.py file has been modified."
           download_chain -l endf -r b8.0

--- a/src/openmc_data/__init__.py
+++ b/src/openmc_data/__init__.py
@@ -7,13 +7,24 @@ except (ModuleNotFoundError, ImportError):
 try:
     __version__ = version("openmc_data")
 except PackageNotFoundError:
-    from setuptools_scm import get_version
-
-    __version__ = get_version(root="..", relative_to=__file__)
+    try:
+        from setuptools_scm import get_version
+    except ModuleNotFoundError:
+        __version__ = "develop"
+    else:
+        __version__ = get_version(root="..", relative_to=__file__)
 
 __all__ = ["__version__"]
 
-from .utils import download, extract, process_neutron, process_thermal, calculate_download_size, get_file_types, state_download_size
+from .utils import (
+    calculate_download_size,
+    download,
+    extract,
+    get_file_types,
+    process_neutron,
+    process_thermal,
+    state_download_size,
+)
 from .urls import all_release_details
 from .urls_h5 import all_h5_release_details
 from .urls_xml import all_chain_release_details

--- a/src/openmc_data/utils.py
+++ b/src/openmc_data/utils.py
@@ -1,18 +1,29 @@
 import hashlib
+import shutil
 import tarfile
 from typing import Iterable
 import warnings
 import zipfile
 from pathlib import Path
-import shutil
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
-import warnings
+
 from .urls import all_release_details
 
-import openmc.data
+try:
+    import openmc.data
+except ModuleNotFoundError:
+    openmc = None
 
 _BLOCK_SIZE = 16384
+
+
+def _require_openmc():
+    if openmc is None:
+        raise ModuleNotFoundError(
+            "openmc is required for neutron and thermal data processing. "
+            "Install openmc before calling this function."
+        )
 
 def state_download_size(compressed_file_size, uncompressed_file_size, units):
     """Prints a standard message to users displaying the amount of storage
@@ -49,6 +60,7 @@ def calculate_download_size(library_name, release, particles, file_type,units='G
 def process_neutron(path, output_dir, libver, temperatures=None):
     """Process ENDF neutron sublibrary file into HDF5 and write into a
     specified output directory."""
+    _require_openmc()
     print(f'Converting: {path}')
     try:
         with warnings.catch_warnings():
@@ -67,6 +79,7 @@ def process_neutron(path, output_dir, libver, temperatures=None):
 def process_thermal(path_neutron, path_thermal, output_dir, libver):
     """Process ENDF thermal scattering sublibrary file into HDF5 and write into a
     specified output directory."""
+    _require_openmc()
     print(f'Converting: {path_thermal}')
     try:
         with warnings.catch_warnings():
@@ -105,7 +118,7 @@ def extract(
     Path.mkdir(extraction_dir, parents=True, exist_ok=True)
 
     print(f'Extracting {compressed_files} to {extraction_dir}')
-    if not isinstance(compressed_files, Iterable):
+    if isinstance(compressed_files, (str, Path)) or not isinstance(compressed_files, Iterable):
         compressed_files = [compressed_files]
 
     for f in compressed_files:
@@ -127,7 +140,8 @@ def extract(
                              f'function {str(f)}')
 
     if del_compressed_file:
-        shutil.rmtree(compressed_files, ignore_errors=True)
+        for compressed_file in compressed_files:
+            Path(compressed_file).unlink(missing_ok=True)
 
 
 def download(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import tarfile
+
+import openmc_data
+
+
+def test_extract_deletes_compressed_files(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    payload = source_dir / "payload.txt"
+    payload.write_text("payload")
+
+    archive = tmp_path / "payload.tar.gz"
+    with tarfile.open(archive, "w:gz") as tgz:
+        tgz.add(payload, arcname=payload.name)
+
+    extraction_dir = tmp_path / "extracted"
+    openmc_data.extract(archive, extraction_dir, del_compressed_file=True, verbose=False)
+
+    assert (extraction_dir / "payload.txt").read_text() == "payload"
+    assert not archive.exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 import tarfile
 
+import pytest
+
 import openmc_data
+from openmc_data import utils
 
 
 def test_extract_deletes_compressed_files(tmp_path):
@@ -18,3 +21,11 @@ def test_extract_deletes_compressed_files(tmp_path):
 
     assert (extraction_dir / "payload.txt").read_text() == "payload"
     assert not archive.exists()
+
+
+def test_process_neutron_requires_openmc():
+    if utils.openmc is not None:
+        pytest.skip("openmc is installed in this environment")
+
+    with pytest.raises(ModuleNotFoundError, match="openmc is required"):
+        openmc_data.process_neutron("dummy.endf", "out", "latest")


### PR DESCRIPTION
Fixes #20 

- Fix extract() crash: shutil.rmtree() was called with a list instead of a single path, and isinstance misclassified strings as iterables
- Make openmc import optional so the package can be imported in CI environments without native OpenMC
- Trigger CI jobs on utils.py changes and fix stale workflow paths