### PR TITLE
Add TENDL-2023 and TENDL-2025 releases to chain generation URL registry

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Install testing dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libhdf5-serial-dev
           git clone --single-branch --branch develop --depth 1 https://github.com/openmc-dev/openmc.git
           cd openmc

--- a/.github/workflows/test_processing.yml
+++ b/.github/workflows/test_processing.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install testing dependencies
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
+          sudo apt-get update
           sudo apt-get install libhdf5-serial-dev
           git clone --single-branch --branch develop --depth 1 https://github.com/openmc-dev/openmc.git
           cd openmc

--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install testing dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libhdf5-serial-dev
           git clone --single-branch --branch develop --depth 1 https://github.com/openmc-dev/openmc.git
           cd openmc

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A few categories of scripts are available:
 |generate_endf_chain | ENDF/B | VII.1<br>VIII.0<br>VIII.1  |
 |generate_jeff_chain | JEFF | 3.3  |
 |generate_jendl_chain | JENDL | 5.0 |
-|generate_tendl_chain | TENDL | 2019<br>2021 |
+|generate_tendl_chain | TENDL | 2019<br>2021<br>2023<br>2025 |
 |generate_serpent_fissq | |  |
 |generate_endf71_chain_casl | ENDF/B |  |
 

--- a/src/openmc_data/depletion/generate_tendl_chain.py
+++ b/src/openmc_data/depletion/generate_tendl_chain.py
@@ -30,11 +30,11 @@ parser.add_argument(
 parser.add_argument(
     "-r",
     "--release",
-    choices=["2015", "2017", "2019", "2021"],
+    choices=["2015", "2017", "2019", "2021", "2023", "2025"],
     default="2021",
     help="The nuclear data library release "
-    "version. The currently supported options are 2019, "
-    "and 2021.",
+    "version. The currently supported options are 2015, 2017, 2019, "
+    "2021, 2023, and 2025.",
 )
 parser.add_argument(
     "-d",

--- a/src/openmc_data/urls_chain.py
+++ b/src/openmc_data/urls_chain.py
@@ -83,6 +83,18 @@ all_decay_release_details = {
                 'base_url': 'https://tendl.imperial.ac.uk/tendl_2021/tar_files/',
                 'compressed_files': ['TENDL-n.tgz'],
             }
+        },
+        '2023': {
+            'neutron':{
+                'base_url': 'https://tendl.imperial.ac.uk/tendl_2023/tar_files/',
+                'compressed_files': ['TENDL-n.2024new.tgz'],
+            }
+        },
+        '2025': {
+            'neutron':{
+                'base_url': 'https://tendl.imperial.ac.uk/tendl_2025/tar_files/',
+                'compressed_files': ['TENDL-n.tgz'],
+            }
         }
     },
     'jendl': {


### PR DESCRIPTION
Closes #30.

TENDL-2023 and TENDL-2025 are available on the Imperial mirror already used for earlier releases. This adds their release entries to `urls_chain.py` and the corresponding release choices to `generate_tendl_chain`.

Issue #30 was scoped to 2025 only, but `urls.py` (used by the cross section conversion scripts) already carried both `tendl 2023` and `tendl 2025` entries while `urls_chain.py` (chain scripts) had neither. This PR adds both so the chain registry reaches parity with `urls.py`.

### Details
- **2025** tarball: `https://tendl.imperial.ac.uk/tendl_2025/tar_files/TENDL-n.tgz` (verified live, Last-Modified July 2025, ~3.5 GB)
- **2023** tarball: `https://tendl.imperial.ac.uk/tendl_2023/tar_files/TENDL-n.2024new.tgz` (verified live, Last-Modified Aug 2024, ~3.1 GB) — note the different filename vs the other releases, matching the entry in `urls.py`

One quirk worth knowing: the TENDL-2025 evaluation headers self-identify as TENDL-2023.1 (NVER=2023, LREL=1), so header-derived library labels will say 2023.1 even for files from the 2025 release.

### Changes
- `src/openmc_data/urls_chain.py`: add `2023` and `2025` entries under `tendl`
- `src/openmc_data/depletion/generate_tendl_chain.py`: add `2023` and `2025` to `--release` choices and update help text
- `README.md`: update the `generate_tendl_chain` release column